### PR TITLE
Update sarah.api.php

### DIFF
--- a/core/api/sarah.api.php
+++ b/core/api/sarah.api.php
@@ -53,7 +53,7 @@ if ($jsonrpc->getMethod() == 'askResult') {
 	}
 
 	if ($cmd->getCache('storeVariable', 'none') != 'none') {
-		$cmd->askResponse(($params['response']);
+		$cmd->askResponse($params['response']);
 	}
 	$jsonrpc->makeSuccess();
 }


### PR DESCRIPTION
Je propose une correction de la ligne 56 où il y a une parenthèse ouvrante en trop. j'ai constaté le problème suite à la dernière maj passée suite au passage de Jeedom en version 3.09